### PR TITLE
Prism and Lente start scripts image & network options

### DIFF
--- a/public/lente.sh
+++ b/public/lente.sh
@@ -26,6 +26,10 @@ fi
 
 # set defaults here
 flag_restart=no
+flag_instno=""
+flag_image="sistemicorp/lente"
+flag_network="host"
+flag_verbose=""
 
 start () {
     echo restart Lente: $flag_restart
@@ -36,49 +40,51 @@ start () {
         echo "--restart= must be always or no"
         exit 1
     fi
-    docker stop lente 2> /dev/null
-    docker rm lente 2> /dev/null
+    docker stop lente${flag_instno} 2> /dev/null
+    docker rm lente${flag_instno} 2> /dev/null
     if [[ $flag_restart == "always" ]]; then
         docker run -d \
-            --network=host \
-            --hostname=${HOSTNAME} \
-            -e OPENBLAS_NUM_THREADS=1 \
-            --security-opt seccomp=unconfined \
-            --security-opt apparmor=unconfined \
+            --network=${flag_network}\
+            --hostname=${HOSTNAME}${flag_instno} \
             --restart=${flag_restart} \
             -v $(pwd):/app/public \
-            --name lente \
-            sistemicorp/lente
+            --name lente${flag_instno} \
+            ${flag_image} \
+	    ${flag_verbose}
     elif [[ $flag_restart == "no" ]]; then
         docker run -d \
-            --network=host \
-            --hostname=${HOSTNAME} \
-            -e OPENBLAS_NUM_THREADS=1 \
-            --security-opt seccomp=unconfined \
-            --security-opt apparmor=unconfined \
+            --network=${flag_network}\
+            --hostname=${HOSTNAME}${flag_instno} \
             -v $(pwd):/app/public \
-            --name lente \
+            --name lente${flag_instno} \
             --rm \
-            sistemicorp/lente
+            ${flag_image} \
+	    ${flag_verbose}
     fi
 }
 
 docker_pull () {
-    echo docker pull latest
-    docker pull sistemicorp/lente:latest
-    docker update --restart=no lente
+    if [[ "${flag_image}" == *":"* ]]; then
+      pull_image=${flag_image}
+    else
+      pull_image=${flag_image}:latest
+    fi
+
+    echo docker pull ${pull_image}
+    docker pull ${pull_image}
+    docker update --restart=no lente${flag_instno}
     echo Stopping Lente...
-    docker stop lente
-    docker container rm lente
+    docker stop lente${flag_instno}
+    docker container rm lente${flag_instno}
     echo
     echo Now restart Lente: ./lente.sh --restart=always start
 }
 
 stop () {
     echo Stopping Lente...
-    docker update --restart=no lente
-    docker stop lente
-    docker container rm lente
+    docker update --restart=no lente${flag_instno}
+    docker stop lente${flag_instno}
+    docker container rm lente${flag_instno}
 }
 
 handle_command () {
@@ -110,6 +116,11 @@ handle_command () {
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -r) flag_restart="$2"; shift 2;;
+    -n) flag_instno="$2"; shift 2;;
+    -i) flag_image="$2"; shift 2;;
+    -b) flag_network="bridge"; shift 1;;
+    -v) flag_verbose="--verbose"; shift 1;;
+
 
     --restart=*) flag_restart="${1#*=}"; shift 1;;
     --restart) echo "$1 requires an argument" >&2; exit 1;;

--- a/public/prism.sh
+++ b/public/prism.sh
@@ -30,6 +30,10 @@ fi
 flag_server_ip=not_specified
 flag_hostname=$(hostname)
 flag_restart=no
+flag_instno=""
+flag_image="sistemicorp/prism"
+flag_network="host"
+
 IP4=$(ip route get 1 | sed -n 's/^.*src \([0-9.]*\) .*$/\1/p')
 
 function valid_ip() {
@@ -71,15 +75,16 @@ start () {
             exit 1
     fi
     echo Using Lente IP = $LENTEIP
-    docker stop prism 2> /dev/null
-    docker rm prism 2> /dev/null
+    echo Using Prism Image = $flag_image
+    docker stop prism${flag_instno} 2> /dev/null
+    docker rm prism${flag_instno} 2> /dev/null
     if [[ $flag_restart == "always" ]]; then
         docker run -d \
-            --network=host \
+            --network=${flag_network}\
+            --hostname=${HOSTNAME}${flag_instno} \
             --restart=${flag_restart} \
             -e LENTEIP=${LENTEIP} \
-            -e HOSTIP=${IP4} \
-            --hostname=${flag_hostname} \
+            --hostname=${flag_hostname}${flag_instno} \
             -v $(pwd):/app/public \
             -v /dev:/dev \
             -v /var/run/dbus/:/var/run/dbus/:z \
@@ -87,14 +92,15 @@ start () {
             --privileged \
             --device /dev/snd \
             --group-add audio \
-            --name prism \
-            sistemicorp/prism
+            --name prism${flag_instno} \
+            ${flag_image}
     elif [[ $flag_restart == "no" ]]; then
         docker run -d \
-            --network=host \
+            --network=${flag_network}\
+            --hostname=${HOSTNAME}${flag_instno} \
             -e LENTEIP=${LENTEIP} \
             -e HOSTIP=${IP4} \
-            --hostname=${flag_hostname} \
+            --hostname=${flag_hostname}${flag_instno} \
             -v $(pwd):/app/public \
             -v /dev:/dev \
             -v /var/run/dbus/:/var/run/dbus/:z \
@@ -102,28 +108,33 @@ start () {
             --privileged \
             --device /dev/snd \
             --group-add audio \
-            --name prism \
+            --name prism${flag_instno} \
             --rm \
-            sistemicorp/prism
+            ${flag_image}
     fi
 }
 
 docker_pull () {
-    echo docker pull latest...
-    docker pull sistemicorp/prism:latest
+    if [[ "${flag_image}" == *":"* ]]; then
+      pull_image=${flag_image}
+    else
+      pull_image=${flag_image}:latest
+    fi
+    echo docker pull ${pull_image}...
+    docker pull ${pull_image}
     echo "Stopping Prism... (if its running)"
-    docker update --restart=no prism
-    docker stop prism
-    docker container rm prism
+    docker update --restart=no prism${flag_instno}
+    docker stop prism${flag_instno}
+    docker container rm prism${flag_instno}
     echo
     echo Now restart Prism: ./prism.sh --server=? --restart=always start
 }
 
 stop () {
     echo "Stopping Prism... (if its running)"
-    docker update --restart=no prism
-    docker stop prism
-    docker container rm prism
+    docker update --restart=no prism${flag_instno}
+    docker stop prism${flag_instno}
+    docker container rm prism${flag_instno}
 }
 
 handle_command () {
@@ -157,6 +168,9 @@ while [ "$#" -gt 0 ]; do
     -r) flag_restart="$2"; shift 2;;
     -h) flag_hostname="$2"; shift 2;;
     -s) flag_server_ip="$2"; shift 2;;
+    -n) flag_instno="$2"; shift 2;;
+    -i) flag_image="$2"; shift 2;;
+    -b) flag_network="bridge"; shift 1;;
 
     --restart=*) flag_restart="${1#*=}"; shift 1;;
     --hostname=*) flag_hostname="${1#*=}"; shift 1;;


### PR DESCRIPTION
Add undocumented development and debug options
  -i: image (default sistemicorp/prism or sistemicorp/lente)
  -b: bridge network (default host)
  -n: instance number to append to container name  (default none)
  -v: verbose debug logging (default INFO logging)
      - Only Lente now.  Prism when Docker file is updated.